### PR TITLE
ログイン画面&ログイン処理の追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,16 +25,16 @@ function App() {
     // ここで認証状態をチェックし、必要に応じてリダイレクト
     if (
       !isAuthenticated() &&
-      location.pathname != "/signup" &&
       location.pathname != "/login" &&
+      location.pathname != "/signup" &&
       location.pathname != "/editUser"
     ) {
-      navigate("/signup");
+      navigate("/login");
     }
     // ログインしている場合はsignupページに遷移できないようにする
     if (
       isAuthenticated() &&
-      (location.pathname == "/signup" || location.pathname == "/login")
+      (location.pathname == "/login" || location.pathname == "/signup")
     ) {
       navigate("/");
     }
@@ -48,12 +48,8 @@ function App() {
     <>
       {/* ヘッダー部分 */}
       <div className="App">
-        <Link to="/">Home</Link>
-        <br />
-        {!isAuthenticated() ? (
-          <Link to="/signup">Signup</Link>
-        ) : (
-          <Link to="/" onClick={handleLogout}>
+        {isAuthenticated() && (
+          <Link to="/login" onClick={handleLogout}>
             Logout
           </Link>
         )}
@@ -64,9 +60,6 @@ function App() {
           <Route path="/editUser" element={<EditUser />} />
         </Routes>
       </div>
-
-      {isAuthenticated() ? "ログインしています。" : "ログインしていません。"}
-      {/* ログイン状態を確認するためです。後に削除 */}
 
       <StoreDashboard userId={userId} />
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import "./App.css";
 import { useEffect } from "react";
-import { StoreDashboard } from "./components/StoreDashboard";
 import {
   BrowserRouter,
   Link,
@@ -12,7 +11,7 @@ import {
 import { EditUser } from "./components/EditUser";
 import { Signup } from "./components/Signup";
 import { Login } from "./components/Login";
-
+import { Home } from "./components/Home";
 import { useSession } from "./hooks/sessionUser";
 
 function App() {
@@ -20,9 +19,8 @@ function App() {
   const navigate = useNavigate(); // 画面遷移をするためにuseNavigate フックを使用
 
   const location = useLocation(); // URLのpathを取得する
-  const userId = "1"; // 仮のユーザID
   useEffect(() => {
-    // ここで認証状態をチェックし、必要に応じてリダイレクト
+    // ログイン前に遷移できるページは条件式に追加する
     if (
       !isAuthenticated() &&
       location.pathname != "/login" &&
@@ -31,12 +29,12 @@ function App() {
     ) {
       navigate("/login");
     }
-    // ログインしている場合はsignupページに遷移できないようにする
+    // ログイン後に遷移できないページは条件式に追加する
     if (
       isAuthenticated() &&
       (location.pathname == "/login" || location.pathname == "/signup")
     ) {
-      navigate("/");
+      navigate("/home");
     }
   }, [getSessionId(), navigate]); // クッキーを削除したと気に、削除前に画面遷移の処理が走ってしまうので、クッキーの削除を監視して削除する
 
@@ -58,10 +56,9 @@ function App() {
           <Route path="/signup" element={<Signup />} />
           <Route path="/login" element={<Login />} />
           <Route path="/editUser" element={<EditUser />} />
+          <Route path="/home" element={<Home />} />
         </Routes>
       </div>
-
-      <StoreDashboard userId={userId} />
     </>
   );
 }

--- a/src/components/EditUser.css
+++ b/src/components/EditUser.css
@@ -9,11 +9,7 @@ label {
 .left-item {
   text-align: left;
 }
-.error {
-  border-color: red;
-}
 
 #sex-gender-canvas {
   background-color: #f0f0f0aa;
-  /* canvasのサイズは動的にするために.tsxの方も記載されている可能性があります。 */
 }

--- a/src/components/EditUser.tsx
+++ b/src/components/EditUser.tsx
@@ -61,7 +61,7 @@ export const EditUser = () => {
         gender: user.gender,
       });
       createSession(id); // idをCookieに保存する
-      navigate("/"); // 画面遷移
+      navigate("/home"); // 画面遷移
     } catch (err) {
       setErrorMessage(`${err}`);
     }

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,0 +1,11 @@
+import { StoreDashboard } from "./StoreDashboard";
+import { useSession } from "../hooks/sessionUser";
+
+export const Home = () => {
+  const { getSessionId } = useSession();
+  return (
+    <>
+      <StoreDashboard userId={getSessionId()} />
+    </>
+  );
+};

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -1,0 +1,52 @@
+.title {
+  display: flex;
+  flex-direction: column;
+}
+
+.login-area {
+  margin: 0 10%;
+  max-width: 800px;
+  max-height: 400px;
+  border-radius: 3px;
+  box-shadow: 0px 5px 30px 20px rgba(0, 0, 200, 0.73);
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  border-radius: 3px 3px 0 0;
+}
+.content-area {
+  position: absolute;
+  background-color: rgba(246, 249, 249, 0.802);
+  top: 60%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  width: 30%;
+  min-width: 150px;
+}
+.login-form {
+  margin: 0 30%;
+  text-align: left;
+  color: #000;
+}
+
+.login-btn {
+  position: relative;
+  width: 50%;
+  margin: 15px 0 20px 0;
+  background-color: rgba(26, 159, 159, 0.646);
+  font-size: x-large;
+}
+
+#signup-link {
+  color: rgb(6, 28, 34);
+  padding: 10px 0 0 0;
+}
+
+.error {
+  border-style: solid;
+  color: red;
+  border-width: 5px;
+}

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -1,10 +1,13 @@
 .title {
+  margin-top: -20%;
   display: flex;
   flex-direction: column;
 }
 
 .login-area {
+  position: relative;
   margin: 0 10%;
+  min-width: 520px;
   max-width: 800px;
   max-height: 400px;
   border-radius: 3px;
@@ -19,12 +22,13 @@
 .content-area {
   position: absolute;
   background-color: rgba(246, 249, 249, 0.802);
-  top: 60%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  top: 0;
+  left: 0;
+  top: 20%;
+  left: 20%;
   text-align: center;
-  width: 30%;
-  min-width: 150px;
+  width: 60%;
+  height: 60%;
 }
 .login-form {
   margin: 0 30%;
@@ -45,8 +49,13 @@
   padding: 10px 0 0 0;
 }
 
-.error {
+.errorFrom {
   border-style: solid;
   color: red;
   border-width: 5px;
+}
+
+.errorMessage {
+  color: red;
+  font-size: 20px;
 }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -15,8 +15,11 @@ export const Login = () => {
   const [email, setEmail] = useState("");
   const { triggerLogin, userId, errorLogin, resetLogin } = loginUser();
   const navigate = useNavigate();
+  const [errorMessages, setErrorMessage] = useState<string>("");
+  useEffect(() => {
+    setInterval(() => changeColor("login-area"), 30);
+  }, []);
 
-  // errorLoginに変更があった際にsetErrorMessageを呼び出す
   useEffect(() => {
     if (errorLogin) {
       console.error(errorLogin);
@@ -44,10 +47,6 @@ export const Login = () => {
     resetLogin();
     await triggerLogin({ email: user.email });
   }
-  const [errorMessages, setErrorMessage] = useState<string>("");
-  useEffect(() => {
-    setInterval(() => changeColor("login-area"), 30);
-  }, []);
 
   return (
     <>
@@ -62,6 +61,9 @@ export const Login = () => {
             <div className="login-form">
               {UserForm.EmailFrom(errorMessages, setEmail)}
             </div>
+            {errorLogin && (
+              <span className="errorMessage">{errorMessages}</span>
+            )}
             <button type="submit" className="login-btn">
               ログイン
             </button>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -19,7 +19,7 @@ export const Login = () => {
   // errorLoginに変更があった際にsetErrorMessageを呼び出す
   useEffect(() => {
     if (errorLogin) {
-      console.log(errorLogin);
+      console.error(errorLogin);
       // 本来であればsetErrorMessage(`${errorLogin}`)とするが、フロントに500番のエラーしか返ってこないので、直接エラーメッセージを入れる
       setErrorMessage("Emailが登録されていません");
     }
@@ -27,6 +27,7 @@ export const Login = () => {
   useEffect(() => {
     if (!errorLogin && userId) {
       createSession(userId);
+      navigate("/home");
     }
   }, [userId]);
 
@@ -42,7 +43,6 @@ export const Login = () => {
     }
     resetLogin();
     await triggerLogin({ email: user.email });
-    !errorLogin && navigate("/");
   }
   const [errorMessages, setErrorMessage] = useState<string>("");
   useEffect(() => {

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,78 @@
+import "./Login.css";
+import { useEffect } from "react";
+import { loginUser } from "../hooks/loginUser";
+import { changeColor } from "../hooks/changeColor";
+import { UserLoginType } from "../types/user";
+import { useNavigate } from "react-router-dom";
+import UserForm from "./UserForm";
+import { useState } from "react";
+import userValidate from "../hooks/userValidation";
+import { useSession } from "../hooks/sessionUser";
+import { EarthVideo } from "./Video"; // 動画ファイルをインポート
+
 export const Login = () => {
+  const { createSession } = useSession();
+  const [email, setEmail] = useState("");
+  const { triggerLogin, userId, errorLogin, resetLogin } = loginUser();
+  const navigate = useNavigate();
+
+  // errorLoginに変更があった際にsetErrorMessageを呼び出す
+  useEffect(() => {
+    if (errorLogin) {
+      console.log(errorLogin);
+      // 本来であればsetErrorMessage(`${errorLogin}`)とするが、フロントに500番のエラーしか返ってこないので、直接エラーメッセージを入れる
+      setErrorMessage("Emailが登録されていません");
+    }
+  }, [errorLogin]);
+  useEffect(() => {
+    if (!errorLogin && userId) {
+      createSession(userId);
+    }
+  }, [userId]);
+
+  async function handleLogin(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const user: UserLoginType = {
+      email: email,
+    };
+    const err = userValidate.validate(user);
+    setErrorMessage(err);
+    if (err != "") {
+      return;
+    }
+    resetLogin();
+    await triggerLogin({ email: user.email });
+    !errorLogin && navigate("/");
+  }
+  const [errorMessages, setErrorMessage] = useState<string>("");
+  useEffect(() => {
+    setInterval(() => changeColor("login-area"), 30);
+  }, []);
+
   return (
     <>
-      <h1>ログイン画面</h1>
+      <h1 className="title">
+        <span>Welcome to </span>
+        <span>Clean Storemap Web</span>
+      </h1>
+      <div className="login-area">
+        {EarthVideo()}
+        <div className="content-area">
+          <form onSubmit={handleLogin}>
+            <div className="login-form">
+              {UserForm.EmailFrom(errorMessages, setEmail)}
+            </div>
+            <button type="submit" className="login-btn">
+              ログイン
+            </button>
+          </form>
+          <div className="login-area-button">
+            <a href="signup" id="signup-link">
+              新規登録の方はこちら
+            </a>
+          </div>
+        </div>
+      </div>
     </>
   );
 };

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -2,7 +2,7 @@ import "./Signup.css";
 import { useEffect } from "react";
 import { signupUser } from "../hooks/signupUser";
 import { changeColor } from "../hooks/changeColor";
-import videoSource from "../assets/earth.mp4"; // 動画ファイルをインポート
+import { EarthVideo } from "./Video"; // 動画ファイルをインポート
 
 export const Signup = () => {
   function handleSignup() {
@@ -20,9 +20,7 @@ export const Signup = () => {
         <span>Clean Storemap Web</span>
       </h1>
       <div className="signup-area">
-        <video autoPlay muted loop className="video">
-          <source src={videoSource} type="video/mp4" />
-        </video>
+        {EarthVideo()}
         <div className="signup-area-button">
           <button onClick={handleSignup} id="signup-btn">
             Googleでサインアップする

--- a/src/components/UserForm.css
+++ b/src/components/UserForm.css
@@ -1,0 +1,3 @@
+.errorFrom {
+  border-color: red;
+}

--- a/src/components/UserForm.tsx
+++ b/src/components/UserForm.tsx
@@ -1,5 +1,6 @@
 import stringHelpers from "../utils/stringHelpers";
 import { ChangeEvent } from "react";
+import "./UserForm.css";
 
 const onChangeInputValue = (e: ChangeEvent<HTMLInputElement>, setFunc: any) => {
   setFunc(e.target.value);
@@ -20,7 +21,7 @@ function NameFrom(errorMessage: string, setNameFunc: any) {
         id="name"
         name="name"
         placeholder="名前を入力してください"
-        className={errorMessage.includes("Name") ? "error" : ""}
+        className={errorMessage.includes("Name") ? "errorFrom" : ""}
         onChange={(e) => onChangeInputValue(e, setNameFunc)}
       />
       <br />
@@ -37,7 +38,7 @@ function EmailFrom(errorMessage: string, setNameFunc: any) {
         id="email"
         name="email"
         placeholder="emailを入力してください"
-        className={errorMessage.includes("Email") ? "error" : ""}
+        className={errorMessage.includes("Email") ? "errorFrom" : ""}
         onChange={(e) => onChangeInputValue(e, setNameFunc)}
       />
       <br />
@@ -57,7 +58,9 @@ function AgeFrom(
       <select
         name="selectedAge"
         className={
-          stringHelpers.includesAny(errorMessage, "年齢", "Age") ? "error" : ""
+          stringHelpers.includesAny(errorMessage, "年齢", "Age")
+            ? "errorFrom"
+            : ""
         }
         onChange={(e) => onChangeSelectValue(e, setAgeFunc)}
       >

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -1,0 +1,10 @@
+import videoSource from "../assets/earth.mp4"; // 動画ファイルをインポート
+export const EarthVideo = () => {
+  return (
+    <>
+      <video autoPlay muted loop className="video">
+        <source src={videoSource} type="video/mp4" />
+      </video>
+    </>
+  );
+};

--- a/src/hooks/loginUser.ts
+++ b/src/hooks/loginUser.ts
@@ -1,0 +1,15 @@
+import useSWRMutation from "swr/mutation";
+import api from "../api/api";
+export const loginUser = () => {
+  const { trigger, isMutating, data, error, reset } = useSWRMutation(
+    `http://localhost:8080/login`,
+    api.sendPostRequest
+  );
+  return {
+    triggerLogin: trigger,
+    isMutatingLogin: isMutating,
+    userId: data?.userId,
+    errorLogin: error,
+    resetLogin: reset,
+  };
+};

--- a/src/hooks/userValidation.ts
+++ b/src/hooks/userValidation.ts
@@ -1,4 +1,4 @@
-import { UserUpdateType } from "../types/user";
+import { User } from "../types/user";
 import stringHelpers from "../utils/stringHelpers";
 
 // フロント側で管理するuser側のvalidation
@@ -21,11 +21,17 @@ const validation = {
   },
 };
 
-// userの入力チェックをする
-function validate(user: UserUpdateType): string {
+function validate(user: Partial<User>): string {
   let error: string = "";
-  error += validation.name(user.name);
-  error += validation.age(user.age);
+  if (user.name) {
+    error += validation.name(user.name);
+  }
+  if (user.email) {
+    error += validation.email(user.email);
+  }
+  if (user.age) {
+    error += validation.age(user.age);
+  }
   return error;
 }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,20 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  age: number;
+  sex: number;
+  gender: number;
+}
+
 export interface UserUpdateType {
   name: string;
   age: number;
   sex: number;
   gender: number;
+}
+
+
+export interface UserLoginType {
+  email: string;
 }


### PR DESCRIPTION
ログインの処理およびログイン画面を追加しました。

## path周り
ルート(login)： /login
signup: /signup
updateUserInfo: /editUser/:Id(ここはURLにidを含むためセッションなしでも遷移できます。)
map：/ home

## 遷移の流れ
- サインアップ
/login => /signup => /editUser/:id => /home
- ログイン
/login => /home

