### PR TITLE
お気に入り登録ボタンを押したらボタンが非表示になる

### DIFF
--- a/src/components/StoreDashboard.tsx
+++ b/src/components/StoreDashboard.tsx
@@ -1,7 +1,6 @@
 import { StoreMap } from "../components/StoreMap";
 import { useNearStores } from "../hooks/useNearStores";
-// import { useFavoriteStores } from "../hooks/useFavoriteStores";
-import { Store } from "../types/store";
+import { useFavoriteStores } from "../hooks/useFavoriteStores";
 
 type Props = {
   userId: string;
@@ -16,20 +15,15 @@ export const StoreDashboard: React.FC<Props> = (props) => {
     resetNearStore,
   } = useNearStores();
 
-  // const { isMutatingFavoriteStore, favoriteStores, errorFavoriteStore } =
-  //   useFavoriteStores(props.userId);
-  // userIdを使ってお気に入りの店舗情報を取得するエンドポイントが完成したら切り替える
-  const favoriteStores: Store[] = [];
-
   function handleCallGetStores() {
     resetNearStore();
     triggerNearStore();
   }
 
+  const { favoriteStores } = useFavoriteStores(props.userId);
+
   return (
     <>
-      <h1>Clean Storemap Web</h1>
-
       <div className="card">
         <button onClick={handleCallGetStores}>店舗情報を取得</button>
         {isMutatingNearStore && <p>データ取得中...</p>}

--- a/src/components/StoreFavoriteButton.tsx
+++ b/src/components/StoreFavoriteButton.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+
+type Props = {
+  isFavorite: boolean;
+  onHandleFavoriteButtonClick: () => void;
+};
+
+export const StoreFavoriteButton: React.FC<Props> = (props) => {
+  const [isFavorite, setIsFavorite] = useState(props.isFavorite);
+  function handleFavoriteButtonClick() {
+    setIsFavorite(true);
+    props.onHandleFavoriteButtonClick();
+  }
+
+  return (
+    <>
+      {isFavorite ? (
+        <p>お気に入り登録済</p>
+      ) : (
+        <button onClick={handleFavoriteButtonClick}>お気に入りに登録</button>
+      )}
+    </>
+  );
+};

--- a/src/components/StoreMap.tsx
+++ b/src/components/StoreMap.tsx
@@ -4,8 +4,8 @@ import { StoreMarker } from "./StoreMarker";
 import { Store } from "../types/store";
 
 const containerStyle = {
-  width: "500px",
-  height: "500px",
+  width: "800px",
+  height: "800px",
 };
 
 type Props = {

--- a/src/components/StoreMarker.tsx
+++ b/src/components/StoreMarker.tsx
@@ -28,6 +28,7 @@ export const StoreMarker: React.FC<Props> = (props) => {
   const map = useMap();
   const [markerRef, marker] = useAdvancedMarkerRef();
   const [infoWindowShown, setInfoWindowShown] = useState(false);
+  const [isFavorite, setIsFavorite] = useState(props.isFavorite);
   const handleMarkerClick = useCallback(
     (ev: google.maps.MapMouseEvent) => {
       if (!map) return;
@@ -35,10 +36,13 @@ export const StoreMarker: React.FC<Props> = (props) => {
       console.log("marker clicked:", ev.latLng.toString());
       map.panTo(ev.latLng);
       props.onMarkerClick();
+      setInfoWindowShown(true);
     },
     [map, props.onMarkerClick]
   );
-  const handleClose = useCallback(() => setInfoWindowShown(false), []);
+  function handleClose() {
+    setInfoWindowShown(false);
+  }
   const { trigger } = useRegisterFavoriteStore(props.userId);
   function handleFavoriteButtonClick() {
     trigger({
@@ -49,6 +53,7 @@ export const StoreMarker: React.FC<Props> = (props) => {
       latitude: props.store.location.latitude,
       longitude: props.store.location.longitude,
     });
+    setIsFavorite(true);
   }
   const dollarIcon = <img src={DollarIcon} alt="DollarIcon" />;
 
@@ -119,7 +124,7 @@ export const StoreMarker: React.FC<Props> = (props) => {
               ))}
           </ul>
           <StoreFavoriteButton
-            isFavorite={props.isFavorite}
+            isFavorite={isFavorite}
             onHandleFavoriteButtonClick={handleFavoriteButtonClick}
           />
         </InfoWindow>

--- a/src/components/StoreMarker.tsx
+++ b/src/components/StoreMarker.tsx
@@ -6,6 +6,7 @@ import {
   useAdvancedMarkerRef,
 } from "@vis.gl/react-google-maps";
 import styles from "./StoreMarker.module.scss";
+import { StoreFavoriteButton } from "./StoreFavoriteButton";
 import DollarIcon from "../assets/dollar.svg";
 import { Store } from "../types/store";
 import { useRegisterFavoriteStore } from "../hooks/useRegisterFavoriteStore";
@@ -117,13 +118,10 @@ export const StoreMarker: React.FC<Props> = (props) => {
                 </li>
               ))}
           </ul>
-          {props.isFavorite ? (
-            <p>お気に入り登録済</p>
-          ) : (
-            <button onClick={handleFavoriteButtonClick}>
-              お気に入りに登録
-            </button>
-          )}
+          <StoreFavoriteButton
+            isFavorite={props.isFavorite}
+            onHandleFavoriteButtonClick={handleFavoriteButtonClick}
+          />
         </InfoWindow>
       )}
     </>

--- a/src/hooks/useFavoriteStores.tsx
+++ b/src/hooks/useFavoriteStores.tsx
@@ -3,7 +3,7 @@ import useSWRMutation from "swr/mutation";
 import api from "../api/api";
 
 export const useFavoriteStores = (userId: string) => {
-  const { trigger, isMutating, data, error, reset } = useSWRMutation(
+  const { trigger, data, reset } = useSWRMutation(
     `http://localhost:8080/user/${userId}/favorite-store`,
     api.sendGetRequest
   );
@@ -14,8 +14,6 @@ export const useFavoriteStores = (userId: string) => {
   }, [reset, trigger]);
 
   return {
-    isMutatingFavoriteStore: isMutating,
     favoriteStores: data?.stores,
-    errorFavoriteStore: error,
   };
 };


### PR DESCRIPTION
※ clean-storemap-api の [PR#32](https://github.com/RinachanBoard31/clean-storemap-api/pull/32) がマージされてから、レビューをお願いします🙏

### 機能

「お気に入りに登録」ボタンを押すと、動的にボタンが「お気に入り登録済」のテキストに変わります。

<img width="237" alt="image" src="https://github.com/user-attachments/assets/6351fe2b-0141-4c3a-bbfd-3d1478bf48a4">
<img width="228" alt="image" src="https://github.com/user-attachments/assets/79362ade-b72d-4523-bac9-cefd358ce055">
