### PR TITLE
userIdを数字型として扱っていたので修正

### DIFF
--- a/src/components/user/UserEdit.tsx
+++ b/src/components/user/UserEdit.tsx
@@ -21,7 +21,7 @@ export const UserEdit = () => {
   // idの取得
   const url = new URL(window.location.href);
   const params = url.searchParams;
-  const id = Number(params.get("id"));
+  const id = params.get("id");
   const { triggerUpdateUser, errorUpdateUser, resetUpdateUser } =
     useUpdateUser(id);
 


### PR DESCRIPTION
※JWTの実装をした際にCookieでuser-idを使用しないのでこの変更は消えます。

clean-storemap-api の [PR#33](https://github.com/RinachanBoard31/clean-storemap-web/compare/fix/user-id?expand=1) でuserのidをuuidに変更した影響で、idをNumber型にしていた部分を変更しました。