### PR TITLE
JWT化に伴うuserIdの削除

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # GoogleのAPIキー
 VITE_GOOGLE_MAPS_API_KEY=
 # 認証トークンのクッキー名
-VITE_AUTH_COOKIE_NAME=auth_token
+VITE_JWT_TOKEN_NAME=auth_token

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# GoogleのAPIキー
+VITE_GOOGLE_MAPS_API_KEY=
+# 認証トークンのクッキー名
+VITE_AUTH_COOKIE_NAME=auth_token

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -5,6 +5,7 @@ async function sendPutRequest<T extends { [key: string]: unknown }>(
   const response = await fetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(arg),
   });
   if (!response.ok) {
@@ -15,6 +16,7 @@ async function sendPutRequest<T extends { [key: string]: unknown }>(
 async function sendGetRequest(url: string) {
   const response = await fetch(url, {
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
   });
   if (!response.ok) {
     throw new Error(`RequestFailed: url:${url} status:${response.status}`);
@@ -38,6 +40,7 @@ async function sendPostRequest<
     method: "POST",
     body: JSON.stringify(arg),
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
   });
   if (!response.ok) {
     throw new Error(`RequestFailed: url:${url} status:${response.status}`);

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,11 +1,9 @@
 import { StoreDashboard } from "./StoreDashboard";
-import { useSession } from "../hooks/auth/useSession";
 
 export const Home = () => {
-  const { getSessionId } = useSession();
   return (
     <>
-      <StoreDashboard userId={getSessionId()} />
+      <StoreDashboard />
     </>
   );
 };

--- a/src/components/StoreDashboard.tsx
+++ b/src/components/StoreDashboard.tsx
@@ -2,11 +2,7 @@ import { StoreMap } from "../components/StoreMap";
 import { useNearStores } from "../hooks/useNearStores";
 import { useFavoriteStores } from "../hooks/useFavoriteStores";
 
-type Props = {
-  userId: string;
-};
-
-export const StoreDashboard: React.FC<Props> = (props) => {
+export const StoreDashboard: React.FC = () => {
   const {
     triggerNearStore,
     isMutatingNearStore,
@@ -20,7 +16,7 @@ export const StoreDashboard: React.FC<Props> = (props) => {
     triggerNearStore();
   }
 
-  const { favoriteStores } = useFavoriteStores(props.userId);
+  const { favoriteStores } = useFavoriteStores();
 
   return (
     <>
@@ -31,11 +27,7 @@ export const StoreDashboard: React.FC<Props> = (props) => {
       </div>
 
       {nearStores && favoriteStores && (
-        <StoreMap
-          userId={props.userId}
-          nearStores={nearStores}
-          favoriteStores={favoriteStores}
-        />
+        <StoreMap nearStores={nearStores} favoriteStores={favoriteStores} />
       )}
     </>
   );

--- a/src/components/StoreMap.tsx
+++ b/src/components/StoreMap.tsx
@@ -9,7 +9,6 @@ const containerStyle = {
 };
 
 type Props = {
-  userId: string;
   nearStores: Store[];
   favoriteStores: Store[];
 };
@@ -41,7 +40,6 @@ export const StoreMap: React.FC<Props> = (props) => {
             {props.nearStores.map((store) => (
               <StoreMarker
                 key={store.id}
-                userId={props.userId}
                 store={store}
                 isActive={activeMarkerId === store.id}
                 isFavorite={favoriteStoreIds.includes(store.id)}

--- a/src/components/StoreMarker.tsx
+++ b/src/components/StoreMarker.tsx
@@ -12,7 +12,6 @@ import { Store } from "../types/store";
 import { useRegisterFavoriteStore } from "../hooks/useRegisterFavoriteStore";
 
 type Props = {
-  userId: string;
   store: Store;
   isActive: boolean;
   isFavorite: boolean;
@@ -43,7 +42,7 @@ export const StoreMarker: React.FC<Props> = (props) => {
   function handleClose() {
     setInfoWindowShown(false);
   }
-  const { trigger } = useRegisterFavoriteStore(props.userId);
+  const { trigger } = useRegisterFavoriteStore();
   function handleFavoriteButtonClick() {
     trigger({
       storeId: props.store.id,

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -4,16 +4,14 @@ import { useState } from "react";
 import { AppTitle } from "../AppTitle";
 import { EarthVideo } from "../EarthVideo"; // 動画ファイルをインポート
 import UserForm from "../user/UserForm";
-import { useLogin } from "../../hooks/auth/useLogin";
+import { loginUser } from "../../hooks/auth/useLogin";
 import { userValidate } from "../../hooks/user/useValidationUser";
-import { useSession } from "../../hooks/auth/useSession";
 import { UserLoginType } from "../../types/user";
 import "../../css/auth/Login.css";
 
 export const Login = () => {
-  const { triggerLogin, userId, errorLogin, resetLogin } = useLogin();
-  const { createSession } = useSession();
   const [email, setEmail] = useState("");
+  const { triggerLogin, errorLogin, resetLogin } = loginUser();
   const [errorMessage, setErrorMessage] = useState<Record<string, string>>({}); // errorMessageはフロント、バックエンドでのエラーが共に入る
   const navigate = useNavigate();
 
@@ -21,16 +19,8 @@ export const Login = () => {
     if (errorLogin) {
       // 本来であればsetErrorMessage(`${errorLogin}`)とするが、フロントに500番のエラーしか返ってこないので、直接エラーメッセージを入れる
       setErrorMessage({ email: "Emailが登録されていません" });
-      console.log(errorMessage);
     }
   }, [errorLogin]);
-
-  useEffect(() => {
-    if (!errorLogin && userId) {
-      createSession(userId);
-      navigate("/home");
-    }
-  }, [userId]);
 
   async function handleLogin() {
     const user: UserLoginType = {
@@ -43,6 +33,8 @@ export const Login = () => {
     }
     resetLogin();
     await triggerLogin({ email: user.email });
+    if (errorLogin) return;
+    navigate("/home");
   }
 
   return (

--- a/src/components/user/UserEdit.tsx
+++ b/src/components/user/UserEdit.tsx
@@ -5,12 +5,10 @@ import { DisplayErrorsWithListTag } from "./DisplayErrorsWithListTag";
 import UserForm from "./UserForm";
 import { useUpdateUser } from "../../hooks/user/useUpdateUser";
 import { userValidate } from "../../hooks/user/useValidationUser";
-import { useSession } from "../../hooks/auth/useSession";
 import { UserUpdateType } from "../../types/user";
 import "../../css/user/UserEdit.css";
 
 export const UserEdit = () => {
-  const { createSession } = useSession();
   // sexとgenderは子コンポーネントとして別関数にしているため親コンポーネントであるここで定義をする。
   const [sex, setSex] = useState<number>(0); // グラフのX座標
   const [gender, setGender] = useState<number>(0); // グラフのY座標
@@ -18,12 +16,8 @@ export const UserEdit = () => {
   const [age, setAge] = useState<number>(-1); // グラフのY座標
   const [errorMessage, setErrorMessage] = useState<Record<string, string>>({});
   const navigate = useNavigate();
-  // idの取得
-  const url = new URL(window.location.href);
-  const params = url.searchParams;
-  const id = Number(params.get("id"));
   const { triggerUpdateUser, errorUpdateUser, resetUpdateUser } =
-    useUpdateUser(id);
+    useUpdateUser();
 
   useEffect(() => {
     if (errorUpdateUser) {
@@ -51,7 +45,6 @@ export const UserEdit = () => {
       sex: user.sex,
       gender: user.gender,
     });
-    createSession(id);
     navigate("/home");
   }
 

--- a/src/hooks/auth/useLogin.ts
+++ b/src/hooks/auth/useLogin.ts
@@ -1,14 +1,13 @@
 import useSWRMutation from "swr/mutation";
 import api from "../../api/api";
-export const useLogin = () => {
-  const { trigger, isMutating, data, error, reset } = useSWRMutation(
+export const loginUser = () => {
+  const { trigger, isMutating, error, reset } = useSWRMutation(
     `http://localhost:8080/login`,
     api.sendPostRequest
   );
   return {
     triggerLogin: trigger,
     isMutatingLogin: isMutating,
-    userId: data?.userId,
     errorLogin: error,
     resetLogin: reset,
   };

--- a/src/hooks/auth/useSession.ts
+++ b/src/hooks/auth/useSession.ts
@@ -1,18 +1,22 @@
 import { useCookies } from "react-cookie";
 
 export const useSession = () => {
-  const [cookies, , removeCookie] = useCookies(["auth_token"]);
+  const cookieName = import.meta.env.VITE_AUTH_COOKIE_NAME;
+  const [cookies, , removeCookie] = useCookies(
+    // import.meta.env.VITE_AUTH_COOKIE_NAME
+    [cookieName]
+  );
 
   const deleteSession = () => {
-    removeCookie("auth_token");
+    removeCookie(cookieName);
   };
 
   const isAuthenticated = () => {
-    return !!cookies.auth_token;
+    return !!cookies[cookieName];
   };
 
   const getSessionId = () => {
-    return cookies.auth_token;
+    return cookies[cookieName];
   };
   return {
     deleteSession,

--- a/src/hooks/auth/useSession.ts
+++ b/src/hooks/auth/useSession.ts
@@ -1,24 +1,20 @@
 import { useCookies } from "react-cookie";
 
 export const useSession = () => {
-  const [cookies, setCookie, removeCookie] = useCookies(["id"]);
-  const createSession = (value: any) => {
-    setCookie("id", value);
-  };
+  const [cookies, , removeCookie] = useCookies(["auth_token"]);
 
   const deleteSession = () => {
-    removeCookie("id");
+    removeCookie("auth_token");
   };
 
   const isAuthenticated = () => {
-    return !!cookies.id;
+    return !!cookies.auth_token;
   };
 
   const getSessionId = () => {
-    return cookies.id;
+    return cookies.auth_token;
   };
   return {
-    createSession,
     deleteSession,
     isAuthenticated,
     getSessionId,

--- a/src/hooks/auth/useSession.ts
+++ b/src/hooks/auth/useSession.ts
@@ -2,10 +2,7 @@ import { useCookies } from "react-cookie";
 
 export const useSession = () => {
   const cookieName = import.meta.env.VITE_AUTH_COOKIE_NAME;
-  const [cookies, , removeCookie] = useCookies(
-    // import.meta.env.VITE_AUTH_COOKIE_NAME
-    [cookieName]
-  );
+  const [cookies, _, removeCookie] = useCookies([cookieName]);
 
   const deleteSession = () => {
     removeCookie(cookieName);

--- a/src/hooks/useFavoriteStores.tsx
+++ b/src/hooks/useFavoriteStores.tsx
@@ -2,9 +2,9 @@ import { useEffect } from "react";
 import useSWRMutation from "swr/mutation";
 import api from "../api/api";
 
-export const useFavoriteStores = (userId: string) => {
+export const useFavoriteStores = () => {
   const { trigger, data, reset } = useSWRMutation(
-    `http://localhost:8080/user/${userId}/favorite-store`,
+    `http://localhost:8080/user/favorite-store`,
     api.sendGetRequest
   );
 

--- a/src/hooks/useRegisterFavoriteStore.tsx
+++ b/src/hooks/useRegisterFavoriteStore.tsx
@@ -1,9 +1,9 @@
 import useSWRMutation from "swr/mutation";
 import api from "../api/api";
 
-export const useRegisterFavoriteStore = (userId: string) => {
+export const useRegisterFavoriteStore = () => {
   const { trigger } = useSWRMutation(
-    `http://localhost:8080/user/${userId}/favorite-store`,
+    `http://localhost:8080/user/favorite-store`,
     api.sendPostRequest
   );
 

--- a/src/hooks/user/useUpdateUser.ts
+++ b/src/hooks/user/useUpdateUser.ts
@@ -1,9 +1,9 @@
 import useSWRMutation from "swr/mutation";
 import api from "../../api/api";
 
-export const useUpdateUser = (userId: any) => {
+export const useUpdateUser = () => {
   const { trigger, isMutating, data, error, reset } = useSWRMutation(
-    `http://localhost:8080/user/${userId}`,
+    `http://localhost:8080/user`,
     api.sendPutRequest
   );
   return {


### PR DESCRIPTION
※[こちら](https://github.com/RinachanBoard31/clean-storemap-api/pull/34)の変更によるものです

JWT化に伴いuserId関連のコードを削除しました。
トークンはCookieで管理しているため、Cookie自体は使用します。


### envについて
VITE_AUTH_COOKIE_NAME=auth_token
の追加をお願いします。